### PR TITLE
Override Blacklight to avoid Searches being written to DB

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -323,4 +323,15 @@ class CatalogController < ApplicationController
   def render_bookmarks_control?
     false
   end
+
+  # OVERRIDE: Modified to not create Search objects in DB and not store in session history
+  def find_or_initialize_search_session_from_params params
+    params_copy = params.reject { |k,v| blacklisted_search_session_params.include?(k.to_sym) or v.blank? }
+
+    return if params_copy.reject { |k,v| [:action, :controller].include? k.to_sym }.blank?
+
+    saved_search = searches_from_history.find { |x| x.query_params == params_copy }
+
+    saved_search ||= Search.new(query_params: params_copy)
+  end
 end


### PR DESCRIPTION
Imago doesn't use saved searches and all of the catalog searches were causing major issues with performance with a sqlite DB.  Skipping writing these to disk should hopefully make imago more performant and less prone to nagios warnings due to DB locking